### PR TITLE
Update causal pathway definition

### DIFF
--- a/DICTIONARY.md
+++ b/DICTIONARY.md
@@ -2,7 +2,7 @@
 A plan specification that is designed to change specified behaviour patterns that may be used in an intervention.
 http://purl.obolibrary.org/obo/cpo_0000053
 ## causal pathway
-A process through which an implementation strategy operates to affect desired implementation outcomes.
+An information content entity about a process through which an implementation strategy operates to affect desired implementation outcomes.
 http://purl.obolibrary.org/obo/cpo_0000029
 ## cognitive moderator
 A moderator that affects the level of influence of an implementation strategy before a mechanism acts on the situation.

--- a/cpo.owl
+++ b/cpo.owl
@@ -17,7 +17,7 @@
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:subsets="http://purl.obolibrary.org/obo/ro/subsets#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/cpo.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/2018-09-21/cpo.owl"/>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/2018-09-24/cpo.owl"/>
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/ro/releases/2018-05-11/ro.owl"/>
         <owl:imports rdf:resource="http://purl.obolibrary.org/obo/iao/2017-03-24/iao.owl"/>
         <dc:description xml:lang="en">This ontology has been designed to conform to BFO and OBO standards and stands in reference to the following works (non-exhaustive):
@@ -340,14 +340,8 @@ From: Pai et al., “Strategies to Enhance Venous Thromboprophylaxis in Hospital
     <!-- http://purl.obolibrary.org/obo/cpo_0000029 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/cpo_0000029">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000015"/>
-        <rdfs:subClassOf>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000057"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/cpo_0000053"/>
-            </owl:Restriction>
-        </rdfs:subClassOf>
-        <obo:IAO_0000115 xml:lang="en">A process through which an implementation strategy operates to affect desired implementation outcomes.</obo:IAO_0000115>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
+        <obo:IAO_0000115 xml:lang="en">An information content entity about a process through which an implementation strategy operates to affect desired implementation outcomes.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Cooper Stansbury</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">Lewis CC, Klasnja P, Powell BJ, Lyon AR, Tuzzio L, Jones S, et al. From Classification to Causality: Advancing Understanding of Mechanisms of Change in Implementation Science. Front Public Health [Internet]. 2018 [cited 2018 Jun 6];6. Available from: https://www.frontiersin.org/articles/10.3389/fpubh.2018.00136/full</obo:IAO_0000119>
         <obo:IAO_0000232 xml:lang="en">A causal pathway is a set of features &quot;of the mechanistic processes through which implementation strategies operate&quot; (Lewis 2018).</obo:IAO_0000232>
@@ -605,32 +599,6 @@ From: Pai et al., “Strategies to Enhance Venous Thromboprophylaxis in Hospital
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/cpo_0000053">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000104"/>
-        <rdfs:subClassOf>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/cpo_0000002"/>
-                    </owl:Restriction>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/cpo_0000004"/>
-                    </owl:Restriction>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/cpo_0000005"/>
-                    </owl:Restriction>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/cpo_0000006"/>
-                    </owl:Restriction>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000051"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/cpo_0000007"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </rdfs:subClassOf>
         <obo:IAO_0000115 xml:lang="en">A plan specification that is designed to change specified behaviour patterns that may be used in an intervention.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Cooper Stansbury</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">Michie S, Stralen MMV, West R. The behaviour change wheel: A new method for characterising and designing behaviour change interventions. Implementation Science. 2011;6(1).</obo:IAO_0000119>


### PR DESCRIPTION
per discussion with ZLL:

causal pathways are the knowledge objects,
not the actual processes.

removed axioms - will add 'has_part' relations
when they are needed